### PR TITLE
Ensure dispatcher and associated functions are defined before calling them

### DIFF
--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -96,10 +96,21 @@ export default class GoogleMapMarkers extends Component {
     this.dimensionsCache_ = {};
   }
 
-  _getState = () => ({
-    children: this.props.dispatcher.getChildren(),
-    updateCounter: this.props.dispatcher.getUpdateCounter(),
-  });
+  _getState = () => {
+    let children = [];
+    let updateCounter = 0;
+
+    if (this.props.dispatcher.getChildren) {
+      children = this.props.dispatcher.getChildren();
+    }
+    if (this.props.dispatcher.getUpdateCounter) {
+      this.props.dispatcher.getUpdateCounter();
+    }
+    return {
+      children,
+      updateCounter,
+    };
+  };
 
   _onChangeHandler = () => {
     if (!this.dimensionsCache_) {


### PR DESCRIPTION
When we upgraded to React 18 we had to create a fork of the `google-map-react` library that we used as the original one isn't well maintained any longer. Since that time we have been seeing some [Sentry errors](https://rome2rio.sentry.io/issues/5497481898/events/3bcd1db8afd740b09c1ab4d24cf77536/?project=4505632747487232&referrer=next-event) relating to this library appearing.

- The errors seem to be exclusively coming from Apple devices, which makes reproducing them impossible for myself
- The errors indicate that either the `dispatcher` property or the `getChildren()` function that exists on `dispatcher` are `undefined`

In this PR I've added a check to ensure that both of these exist before calling `getChildren()`. Similarly I've added a check for the subsequent `getUpdateCounter()` function that is called.

I'm not entirely sure if this approach will work.